### PR TITLE
Feature/maps 298 use official schemas

### DIFF
--- a/open-api.json
+++ b/open-api.json
@@ -1015,7 +1015,13 @@
                     },
                     "type": {
                         "description": "Specifies the penalty users have to pay at time of booking. Must be of one of the following strings :\n- unknown\n- full_refundable\n- partial_refundable\n- non_refundable",
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                            "unknown",
+                            "full_refundable",
+                            "partial_refundable",
+                            "non_refundable"
+                        ]
                     }
                 },
                 "type": "object"
@@ -2332,7 +2338,24 @@
                     },
                     "room_type": {
                         "description": "Must be one of:\n- STANDARD\n- COMFORT\n- FAMILY\n- DELUXE\n- SUPERIOR\n- EXECUTIVE\n- JUNIOR_SUITE\n- SUITE\n- EXECUTIVE_SUITE\n- STUDIO\n- APARTMENT\n- BUNGALOW\n- VILLA\n- SHARED\n- OTHERS\nIf room_type field is not provided, room_group.name is used. If room_group.name is missing as well, the field \"name\" of the RoomType object is used.",
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                            "STANDARD",
+                            "COMFORT",
+                            "FAMILY",
+                            "DELUXE",
+                            "SUPERIOR",
+                            "EXECUTIVE",
+                            "JUNIOR_SUITE",
+                            "SUITE",
+                            "EXECUTIVE_SUITE",
+                            "STUDIO",
+                            "APARTMENT",
+                            "BUNGALOW",
+                            "VILLA",
+                            "SHARED",
+                            "OTHERS"
+                        ]
                     },
                     "room_group": {
                         "description": "An identifier, which groups different rates to a specified room. All elements with the same room_group.code relates to the same real room (physical).",

--- a/open-api.json
+++ b/open-api.json
@@ -1135,7 +1135,7 @@
                     "percentage": {
                         "description": "Percentage value of the discount. Mandatory, only if total is not provided.",
                         "type": "number",
-                        "format": "float"
+                        "format": "number"
                     },
                     "total": {
                         "$ref": "#/components/schemas/price"
@@ -1253,12 +1253,12 @@
                     "latitude": {
                         "description": "Latitude coordinate",
                         "type": "number",
-                        "format": "float"
+                        "format": "number"
                     },
                     "longitude": {
                         "description": "Longitude coordinate",
                         "type": "number",
-                        "format": "float"
+                        "format": "number"
                     },
                     "url": {
                         "description": "URL for general hotel contact",
@@ -1942,7 +1942,7 @@
                     "interest_charge": {
                         "description": "Interest rate per installment",
                         "type": "number",
-                        "format": "float"
+                        "format": "number"
                     },
                     "extra_charge": {
                         "$ref": "#/components/schemas/price"
@@ -2057,7 +2057,7 @@
                     "amount": {
                         "description": "The value of the price.",
                         "type": "number",
-                        "format": "float"
+                        "format": "number"
                     },
                     "currency": {
                         "description": "ISO 4217 currency code for the price.",

--- a/open-api.json
+++ b/open-api.json
@@ -331,7 +331,8 @@
                     },
                     "terms_and_conditions": {
                         "description": "General terms and conditions.\nText field.\nLength limit of 1000 characters.",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 1000
                     },
                     "terms_and_conditions_url": {
                         "description": "Link to the advertiser's terms and conditions page.",
@@ -339,11 +340,13 @@
                     },
                     "payment_policy": {
                         "description": "Describes how the advertiser will use the credit card information, e.g. charged immediately or hold.\nText field.\nLength limit of 1000 characters.",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 1000
                     },
                     "other_policy": {
                         "description": "Miscellaneous policies\nText field.\nLength limit of 1000 characters.",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 1000
                     },
                     "errors": {
                         "description": "Array of errors",
@@ -1168,7 +1171,8 @@
                     },
                     "message": {
                         "description": "String describing the error (maximum length of 1000 characters).",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 1000
                     },
                     "timeout": {
                         "description": "Number of seconds trivago should stop sending requests (for use with Error Code 4).",
@@ -2319,7 +2323,8 @@
                 "properties": {
                     "name": {
                         "description": "Short description of the room type. This will be displayed to users, and should be in the language indicated by\nthe 'lang' parameter (max length of 120 characters).",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 120
                     },
                     "rate_key": {
                         "description": "Unique identifier for this rate. Used to identify a rate across several \"/booking_availability\" requests. E.g.\nif an user stays on the landing page for a longer period of time before clicking on a specific rate another\n\"/booking_availability\" request is submitted to ensure that the rate clicked is still bookable.\nIf no rate_key is provided a rate is identified based on rate attributes and rate components.",
@@ -2347,7 +2352,8 @@
                     },
                     "description": {
                         "description": "Longer room description. Will be displayed to users, and should be in the language indicated by the 'lang' parameter (max length of 1000 characters).",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 1000
                     },
                     "rooms_available": {
                         "description": "The number of rooms remaining/available.",
@@ -2423,6 +2429,7 @@
                     "cancellation_policy": {
                         "description": "Text describing the cancellation policy for the room. Should be in the language indicated by the 'lang'\nparameter. Text field.Length limit: 1000 characters.",
                         "type": "string",
+                        "maxLength": 1000,
                         "deprecated": true
                     },
                     "cancellation_deadline": {
@@ -2432,15 +2439,18 @@
                     },
                     "occupancy_policy": {
                         "description": "Occupancy policies for this room e.g. maximum number of adults, minimum ages.Text field.Length\nlimit: 1000 characters.",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 1000
                     },
                     "payment_policy": {
                         "description": "Describes how the advertiser will use the credit card information, e.g. charged immediately or hold.\n(Length limit: 1000 characters).",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 1000
                     },
                     "other_policy": {
                         "description": "Miscellaneous policies.Text field (Length limit: 1000 characters).",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 1000
                     },
                     "promotions": {
                         "description": "Array of promotions",
@@ -2504,7 +2514,8 @@
                     },
                     "description": {
                         "description": "Description of the real room limited to 1000 characters.",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 1000
                     }
                 },
                 "type": "object"

--- a/schemas/booking-availability-response-success.json
+++ b/schemas/booking-availability-response-success.json
@@ -44,7 +44,8 @@
     },
     "terms_and_conditions": {
       "description": "General terms and conditions.\nText field.\nLength limit of 1000 characters.",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     },
     "terms_and_conditions_url": {
       "description": "Link to the advertiser's terms and conditions page.",
@@ -52,11 +53,13 @@
     },
     "payment_policy": {
       "description": "Describes how the advertiser will use the credit card information, e.g. charged immediately or hold.\nText field.\nLength limit of 1000 characters.",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     },
     "other_policy": {
       "description": "Miscellaneous policies\nText field.\nLength limit of 1000 characters.",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     },
     "errors": {
       "description": "Array of errors",

--- a/schemas/cancellation.json
+++ b/schemas/cancellation.json
@@ -18,7 +18,13 @@
     },
     "type": {
       "description": "Specifies the penalty users have to pay at time of booking. Must be of one of the following strings :\n- unknown\n- full_refundable\n- partial_refundable\n- non_refundable",
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "unknown",
+        "full_refundable",
+        "partial_refundable",
+        "non_refundable"
+      ]
     }
   },
   "type": "object",

--- a/schemas/discount.json
+++ b/schemas/discount.json
@@ -5,7 +5,7 @@
     "percentage": {
       "description": "Percentage value of the discount. Mandatory, only if total is not provided.",
       "type": "number",
-      "format": "float"
+      "format": "number"
     },
     "total": {
       "$ref": "price.json"

--- a/schemas/error.json
+++ b/schemas/error.json
@@ -11,7 +11,8 @@
     },
     "message": {
       "description": "String describing the error (maximum length of 1000 characters).",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     },
     "timeout": {
       "description": "Number of seconds trivago should stop sending requests (for use with Error Code 4).",

--- a/schemas/hotel-details.json
+++ b/schemas/hotel-details.json
@@ -70,7 +70,8 @@
     },
     "checkinout_policy": {
       "description": "Describes the check-in/check-out policy for the hotel. Should be in the language indicated by the 'lang'\nparameter. Max length 1000 characters.",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     }
   },
   "type": "object",

--- a/schemas/hotel-details.json
+++ b/schemas/hotel-details.json
@@ -39,12 +39,12 @@
     "latitude": {
       "description": "Latitude coordinate",
       "type": "number",
-      "format": "float"
+      "format": "number"
     },
     "longitude": {
       "description": "Longitude coordinate",
       "type": "number",
-      "format": "float"
+      "format": "number"
     },
     "url": {
       "description": "URL for general hotel contact",

--- a/schemas/installment.json
+++ b/schemas/installment.json
@@ -34,7 +34,7 @@
     "interest_charge": {
       "description": "Interest rate per installment",
       "type": "number",
-      "format": "float"
+      "format": "number"
     },
     "extra_charge": {
       "$ref": "price.json"

--- a/schemas/price.json
+++ b/schemas/price.json
@@ -9,7 +9,7 @@
     "amount": {
       "description": "The value of the price.",
       "type": "number",
-      "format": "float"
+      "format": "number"
     },
     "currency": {
       "description": "ISO 4217 currency code for the price.",

--- a/schemas/room-group.json
+++ b/schemas/room-group.json
@@ -16,7 +16,8 @@
     },
     "description": {
       "description": "Description of the real room limited to 1000 characters.",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     }
   },
   "type": "object",

--- a/schemas/room-type.json
+++ b/schemas/room-type.json
@@ -12,7 +12,8 @@
   "properties": {
     "name": {
       "description": "Short description of the room type. This will be displayed to users, and should be in the language indicated by\nthe 'lang' parameter (max length of 120 characters).",
-      "type": "string"
+      "type": "string",
+      "maxLength": 120
     },
     "rate_key": {
       "description": "Unique identifier for this rate. Used to identify a rate across several \"/booking_availability\" requests. E.g.\nif an user stays on the landing page for a longer period of time before clicking on a specific rate another\n\"/booking_availability\" request is submitted to ensure that the rate clicked is still bookable.\nIf no rate_key is provided a rate is identified based on rate attributes and rate components.",
@@ -40,7 +41,8 @@
     },
     "description": {
       "description": "Longer room description. Will be displayed to users, and should be in the language indicated by the 'lang' parameter (max length of 1000 characters).",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     },
     "rooms_available": {
       "description": "The number of rooms remaining/available.",
@@ -116,7 +118,8 @@
     "cancellation_policy": {
       "description": "Text describing the cancellation policy for the room. Should be in the language indicated by the 'lang'\nparameter. Text field.Length limit: 1000 characters.",
       "type": "string",
-      "deprecated": true
+      "deprecated": true,
+      "maxLength": 1000
     },
     "cancellation_deadline": {
       "description": "The datetime after which it is not free to cancel a reservation.The format must match YYYY-MM-DDThh:mm:ss. Note\nthere is no timezone info because it's localized to the property.\nExample: \"cancellation_deadline\": \"2015-05-25T16:00:00\"",
@@ -125,15 +128,18 @@
     },
     "occupancy_policy": {
       "description": "Occupancy policies for this room e.g. maximum number of adults, minimum ages.Text field.Length\nlimit: 1000 characters.",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     },
     "payment_policy": {
       "description": "Describes how the advertiser will use the credit card information, e.g. charged immediately or hold.\n(Length limit: 1000 characters).",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     },
     "other_policy": {
       "description": "Miscellaneous policies.Text field (Length limit: 1000 characters).",
-      "type": "string"
+      "type": "string",
+      "maxLength": 1000
     },
     "promotions": {
       "description": "Array of promotions",

--- a/schemas/room-type.json
+++ b/schemas/room-type.json
@@ -21,7 +21,24 @@
     },
     "room_type": {
       "description": "Must be one of:\n- STANDARD\n- COMFORT\n- FAMILY\n- DELUXE\n- SUPERIOR\n- EXECUTIVE\n- JUNIOR_SUITE\n- SUITE\n- EXECUTIVE_SUITE\n- STUDIO\n- APARTMENT\n- BUNGALOW\n- VILLA\n- SHARED\n- OTHERS\nIf room_type field is not provided, room_group.name is used. If room_group.name is missing as well, the field \"name\" of the RoomType object is used.",
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "STANDARD",
+        "COMFORT",
+        "FAMILY",
+        "DELUXE",
+        "SUPERIOR",
+        "EXECUTIVE",
+        "JUNIOR_SUITE",
+        "SUITE",
+        "EXECUTIVE_SUITE",
+        "STUDIO",
+        "APARTMENT",
+        "BUNGALOW",
+        "VILLA",
+        "SHARED",
+        "OTHERS"
+      ]
     },
     "room_group": {
       "description": "An identifier, which groups different rates to a specified room. All elements with the same room_group.code relates to the same real room (physical).",


### PR DESCRIPTION
Hi there,

As I already told @AhmedDeif & @rafaces we would like to use the JSON schema files in this repository to feed an API validation tool we're working on. To be able to do so I would like to propose one important and some minor changes:

* There is only one change here that is in my opinion really important which is the one regarding the usage of `"format": "float"`. Apparently `float` is called `number` in JSON schema (https://json-schema.org/understanding-json-schema/reference/numeric.html#number) so I fear the library we use (https://github.com/ajv-validator/ajv) could choke on this.

* Other than that I simply translated restrictions that were only formulated in a field's description into enums and max lengths for strings. That way the users of our tool are able to catch more errors automatically.

